### PR TITLE
include non-enumerable properties of objects

### DIFF
--- a/cycle.js
+++ b/cycle.js
@@ -88,15 +88,34 @@ cycle.decycle = function decycle(object) {
 // If it is an object, replicate the object.
 
                 nu = {};
-                for (name in value) {
+
+                var obj = value,
+                    props = [],
+                    prop,
+                    names,
+                    name;
+
+                do {
+                    names = Object.getOwnPropertyNames(obj);
+                    for (i = 0; i < names.length; i+=1) {
+                        prop = names[i];
+                        if (props.indexOf(prop) === -1) {
+                            props.push(prop);
+                        }
+                    }
+                } while (obj = Object.getPrototypeOf(obj));
+
+                for (i = 0; i < props.length; i +=1) {
+                    name = props[i];
                     if (Object.prototype.hasOwnProperty.call(value, name)) {
-                        nu[name] = derez(value[name],
-                            path + '[' + JSON.stringify(name) + ']');
+                        nu[name] = derez(value[name], path + '[' + JSON.stringify(name) + ']');
                     }
                 }
             }
+
             return nu;
         }
+
         return value;
     }(object, '$'));
 };


### PR DESCRIPTION
A problem occurred as the message from an `Error` were not available after decycle. Not the best syntax, but the implementation orientates towards the original code.
