### PR TITLE
Use an SPDX compatable license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,12 @@
+cycle.js
+2013-02-19
+
+Public Domain.
+
+NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+This code should be minified before deployment.
+See http://javascript.crockford.com/jsmin.html
+
+USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO
+NOT CONTROL.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 , "version"     : "1.0.3"
 , "main"        : "./cycle.js"
 , "homepage"    : "https://github.com/douglascrockford/JSON-js"
-, "license"     : "Public-Domain"
+, "license"     : "SEE LICENSE IN ./LICENSE"
 , "repository"  :
   { "type": "git", "url": "http://github.com/dscape/cycle.git" }
 , "bugs"        : "http://github.com/douglascrockford/JSON-js/issues"


### PR DESCRIPTION
Public-Domain isn't machine readable, and cannot be machine readable
because it's legally vague.

See: https://wiki.spdx.org/view/Legal_Team/Decisions/Dealing_with_Public_Domain_within_SPDX_Files