### PR TITLE
Fix the package.json formatting to allow for better parsing by NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,22 @@
-{ "name"        : "cycle"
-, "description" : "decycle your json"
-, "author"      : ""
-, "version"     : "1.0.3"
-, "main"        : "./cycle.js"
-, "homepage"    : "https://github.com/douglascrockford/JSON-js"
-, "license"     : "Public-Domain"
-, "repository"  :
-  { "type": "git", "url": "http://github.com/dscape/cycle.git" }
-, "bugs"        : "http://github.com/douglascrockford/JSON-js/issues"
-, "keywords"    : [ "json", "cycle", "stringify", "parse" ]
-, "engines"     : { "node" : ">=0.4.0" }
+{
+  "name": "cycle",
+  "description": "decycle your json",
+  "author": "",
+  "version": "1.0.3",
+  "main": "./cycle.js",
+  "license": "Public-Domain",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/dscape/cycle.git"
+  },
+  "bugs": "http://github.com/douglascrockford/JSON-js/issues",
+  "keywords": [
+    "json",
+    "cycle",
+    "stringify",
+    "parse"
+  ],
+  "engines": {
+    "node": ">=0.4.0"
+  }
 }


### PR DESCRIPTION
This Pull request formats the `package.json` file to use standard JSON formatting.

While the existing `package.json` file is technically valid JSON, it uses non-standard formatting which actually breaks some features in `npm install`.


For example, when running `npm install`, and inspecting the resulting `package.json` file inside of the `node_modules` folder, there are a few fields missing, namely the `'license'` field.

>`node_modules/cycle/package.json` before this change:
```
  . . .
  "keywords": [
    "json",
    "cycle",
    "stringify",
    "parse"
  ],
  "main": "./cycle.js",
  "name": "cycle",
  "repository": {
    "type": "git",
    "url": "git+ssh://git@github.com/dscape/cycle.git"
  },
  "version": "1.0.3"
}
```

>and after this change:
```json
  . . .
  "keywords": [
    "json",
    "cycle",
    "stringify",
    "parse"
  ],
  "license": "Public-Domain",
  "main": "./cycle.js",
  "name": "cycle",
  "repository": {
    "type": "git",
    "url": "git+ssh://git@github.com/dscape/cycle.git"
  },
  "version": "1.0.3"
}
```